### PR TITLE
Update symmetry property and add compute_symmetry_reduced_orientations as alternative to set_symmetry

### DIFF
--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -49,7 +49,7 @@ from tqdm import tqdm
 
 from orix.quaternion.orientation_region import OrientationRegion
 from orix.quaternion.rotation import Rotation
-from orix.quaternion.symmetry import C1
+from orix.quaternion.symmetry import C1, Symmetry
 from orix.scalar import Scalar
 from orix._util import deprecated
 
@@ -127,6 +127,15 @@ class Misorientation(Rotation):
         """Tuple of :class:`~orix.quaternion.Symmetry`."""
         return self._symmetry
 
+    @symmetry.setter
+    def symmetry(self, values):
+        err_message = "Values must be a tuple of two Symmetry objects."
+        if not isinstance(values, (list, tuple)):
+            raise TypeError(err_message)
+        if len(values) != 2 or not all(isinstance(s, Symmetry) for s in values):
+            raise ValueError(err_message)
+        self._symmetry = values
+
     def __getitem__(self, key):
         m = super().__getitem__(key)
         m._symmetry = self._symmetry
@@ -155,8 +164,31 @@ class Misorientation(Rotation):
 
     def set_symmetry(self, Gl, Gr, verbose=False):
         """Assign symmetries to this misorientation.
-
         Computes equivalent transformations which have the smallest
+        angle of rotation and assigns these in-place.
+        Parameters
+        ----------
+        Gl, Gr : Symmetry
+        Returns
+        -------
+        Misorientation
+            A new misorientation object with the assigned symmetry.
+        Examples
+        --------
+        >>> from orix.quaternion.symmetry import C4, C2
+        >>> data = np.array([[0.5, 0.5, 0.5, 0.5], [0, 1, 0, 0]])
+        >>> m = Misorientation(data).set_symmetry(C4, C2)
+        >>> m
+        Misorientation (2,) 4, 2
+        [[-0.7071  0.7071  0.      0.    ]
+        [ 0.      1.      0.      0.    ]]
+        """
+        misori = self.__class__(self.data)
+        misori._symmetry = (Gl, Gr)
+        return misori.compute_symmetry_reduced_orientations()
+
+    def compute_symmetry_reduced_orientations(self, verbose=False):
+        """Computes equivalent transformations which have the smallest
         angle of rotation and assigns these in-place.
 
         Parameters
@@ -178,6 +210,7 @@ class Misorientation(Rotation):
         [[-0.7071  0.7071  0.      0.    ]
         [ 0.      1.      0.      0.    ]]
         """
+        Gl, Gr = self._symmetry
         symmetry_pairs = iproduct(Gl, Gr)
         if verbose:
             symmetry_pairs = tqdm(symmetry_pairs, total=Gl.size * Gr.size)
@@ -400,7 +433,8 @@ class Orientation(Misorientation):
         if isinstance(other, Orientation):
             # Call to Object3d.squeeze() doesn't carry over symmetry
             misorientation = Misorientation(self * ~other).squeeze()
-            return misorientation.set_symmetry(self.symmetry, other.symmetry)
+            misorientation.symmetry = (self.symmetry, other.symmetry)
+            return misorientation.compute_symmetry_reduced_orientations()
         return NotImplemented
 
     @classmethod

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -181,6 +181,7 @@ class TestOrientationInitialization:
         assert np.allclose(o1.data, [0, -0.3827, 0, -0.9239], atol=1e-4)
         assert o1.symmetry.name == "1"
         o2 = Orientation.from_euler(euler, symmetry=Oh)
+        o2 = o2.compute_symmetry_reduced_orientations()
         assert np.allclose(o2.data, [0.9239, 0, 0.3827, 0], atol=1e-4)
         assert o2.symmetry.name == "m-3m"
         o3 = o1.set_symmetry(Oh)
@@ -196,6 +197,7 @@ class TestOrientationInitialization:
         )
         assert o1.symmetry.name == "1"
         o2 = Orientation.from_matrix(om, symmetry=Oh)
+        o2 = o2.compute_symmetry_reduced_orientations()
         assert np.allclose(
             o2.data, np.array([1, 0, 0, 0] * 2 + [-1, 0, 0, 0] * 2).reshape((4, 4))
         )
@@ -209,6 +211,7 @@ class TestOrientationInitialization:
         assert np.allclose(o1.data, [0.7071, 0, 0, 0.7071])
         assert o1.symmetry.name == "1"
         o2 = Orientation.from_neo_euler(v, symmetry=Oh)
+        o2 = o2.compute_symmetry_reduced_orientations()
         assert np.allclose(o2.data, [-1, 0, 0, 0])
         assert o2.symmetry.name == "m-3m"
         o3 = o1.set_symmetry(Oh)


### PR DESCRIPTION
From the discussion in #235 and #233, I wanted to update the use of the symmetry property, with the possibility to add a to-be-decided renamed ```set_symmetry``` function, which will perform the same operation. ```set_symmetry``` is left untouched to keep the tests passing, but now the work is performed in the to-be-decided renamed ```set_symmetry``` function which requires no symmetry arguments. The tests have been updated to call the new function to return the same values as previously calculated with ```set_symmetry```.